### PR TITLE
v3.4.1b

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Dropped Moodle 3.4 support
 
+## 3.4.1b (May 8, 2020) by [@FurloSK](https://github.com/FurloSK/moodle-local_feedbackviewer)
+
+- When labels are present in feedback, their proper text is displayed instead of empty 'label' sign
+
 ## 3.4.1 (May 19, 2019)
 
 - Minor code cleanup

--- a/README.md
+++ b/README.md
@@ -19,4 +19,5 @@ The plugin has no options; once installed it may be accessed through Course admi
 
 Author
 -----
-Charles Fulton (fultonc@lafayette.edu)
+- Charles Fulton (fultonc@lafayette.edu)
+- minor contributions by [@FurloSK](https://github.com/FurloSK/moodle-local_feedbackviewer)

--- a/classes/display.php
+++ b/classes/display.php
@@ -68,7 +68,12 @@ class display extends \mod_feedback_responses_table {
     public function build_table() {
         $headers = array();
         foreach ($this->feedbackstructure->get_items() as $id => $item) {
-            $headers[$id] = $item->name;
+            if ($item->typ == 'label') {
+                $headers[$id] = \html_writer::tag('div', $item->presentation, array('class' => 'fitemlabel'));
+            }
+            else {
+                $headers[$id] = $item->name;
+            }
         }
 
         foreach ($this->rawdata as $row) {

--- a/version.php
+++ b/version.php
@@ -24,11 +24,11 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version   = 2018051301;
+$plugin->version   = 2020050802;
 $plugin->requires  = 2018120300;
 $plugin->component = 'local_feedbackviewer';
 $plugin->maturity  = MATURITY_STABLE;
-$plugin->release   = 'v3.4.1';
+$plugin->release   = 'v3.4.1b';
 $plugin->dependencies = array(
     'mod_feedback' => 2017051500
 );


### PR DESCRIPTION
Hi, I just created a patched version 3.4.1b with a single small change:
- When labels are present in feedback, their proper text is displayed instead of empty 'label' sign
